### PR TITLE
Keep implementation in sync with other Bevy 0.7 changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_pixel_camera"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["drakmaniso <moussault.laurent@gmail.com>"]
 edition = "2021"
 description = "A simple pixel-perfect camera plugin for Bevy, suitable for pixel-art"

--- a/src/pixel_camera.rs
+++ b/src/pixel_camera.rs
@@ -121,8 +121,10 @@ impl CameraProjection for PixelProjection {
             self.right,
             self.bottom,
             self.top,
-            self.near,
+            // NOTE: near and far are swapped to invert the depth range from [0,1] to [1,0]
+            // This is for interoperability with pipelines using infinite reverse perspective projections.
             self.far,
+            self.near,
         )
     }
 

--- a/src/pixel_camera.rs
+++ b/src/pixel_camera.rs
@@ -1,7 +1,9 @@
+use bevy::math::Vec3;
 use bevy::prelude::{
     Bundle, Component, GlobalTransform, Mat4, Reflect, ReflectComponent, Transform,
 };
 use bevy::render::camera::{Camera, Camera2d, CameraProjection, DepthCalculation};
+use bevy::render::primitives::Frustum;
 use bevy::render::view::VisibleEntities;
 
 /// Provides the components for the camera entity.
@@ -13,6 +15,7 @@ pub struct PixelCameraBundle {
     pub camera: Camera,
     pub pixel_projection: PixelProjection,
     pub visible_entities: VisibleEntities,
+    pub frustum: Frustum,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
     pub marker: Camera2d,
@@ -22,15 +25,18 @@ impl PixelCameraBundle {
     /// Create a component bundle for a camera where the size of virtual pixels
     /// are specified with `zoom`.
     pub fn from_zoom(zoom: i32) -> Self {
-        let projection = PixelProjection {
+        let pixel_projection = PixelProjection {
             zoom: zoom,
             ..Default::default()
         };
-        let far = projection.far;
+        let far = pixel_projection.far;
+        let view_projection = pixel_projection.get_projection_matrix();
+        let frustum = Frustum::from_view_projection(&view_projection, &Vec3::ZERO, &Vec3::Z, far);
         Self {
             camera: Camera::default(),
-            pixel_projection: projection,
+            pixel_projection,
             visible_entities: Default::default(),
+            frustum,
             transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
             global_transform: Default::default(),
             marker: Camera2d,
@@ -40,16 +46,19 @@ impl PixelCameraBundle {
     /// Create a component bundle for a camera where the size of virtual pixels
     /// is automatically set to fit the specified resolution inside the window.
     pub fn from_resolution(width: i32, height: i32) -> Self {
-        let far = 1000.0;
+        let pixel_projection = PixelProjection {
+            desired_width: Some(width),
+            desired_height: Some(height),
+            ..Default::default()
+        };
+        let far = pixel_projection.far;
+        let view_projection = pixel_projection.get_projection_matrix();
+        let frustum = Frustum::from_view_projection(&view_projection, &Vec3::ZERO, &Vec3::Z, far);
         Self {
             camera: Camera::default(),
-
-            pixel_projection: PixelProjection {
-                desired_width: Some(width),
-                desired_height: Some(height),
-                ..Default::default()
-            },
+            pixel_projection,
             visible_entities: Default::default(),
+            frustum,
             transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
             global_transform: Default::default(),
             marker: Camera2d,
@@ -59,14 +68,18 @@ impl PixelCameraBundle {
     /// Create a component bundle for a camera where the size of virtual pixels
     /// is automatically set to fit the specified width inside the window.
     pub fn from_width(width: i32) -> Self {
-        let far = 1000.0;
+        let pixel_projection = PixelProjection {
+            desired_width: Some(width),
+            ..Default::default()
+        };
+        let far = pixel_projection.far;
+        let view_projection = pixel_projection.get_projection_matrix();
+        let frustum = Frustum::from_view_projection(&view_projection, &Vec3::ZERO, &Vec3::Z, far);
         Self {
             camera: Camera::default(),
-            pixel_projection: PixelProjection {
-                desired_width: Some(width),
-                ..Default::default()
-            },
+            pixel_projection,
             visible_entities: Default::default(),
+            frustum,
             transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
             global_transform: Default::default(),
             marker: Camera2d,
@@ -76,14 +89,18 @@ impl PixelCameraBundle {
     /// Create a component bundle for a camera where the size of virtual pixels
     /// is automatically set to fit the specified height inside the window.
     pub fn from_height(height: i32) -> Self {
-        let far = 1000.0;
+        let pixel_projection = PixelProjection {
+            desired_height: Some(height),
+            ..Default::default()
+        };
+        let far = pixel_projection.far;
+        let view_projection = pixel_projection.get_projection_matrix();
+        let frustum = Frustum::from_view_projection(&view_projection, &Vec3::ZERO, &Vec3::Z, far);
         Self {
             camera: Camera::default(),
-            pixel_projection: PixelProjection {
-                desired_height: Some(height),
-                ..Default::default()
-            },
+            pixel_projection,
             visible_entities: Default::default(),
+            frustum,
             transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
             global_transform: Default::default(),
             marker: Camera2d,

--- a/src/pixel_camera.rs
+++ b/src/pixel_camera.rs
@@ -1,4 +1,3 @@
-use bevy::math::Vec3;
 use bevy::prelude::{
     Bundle, Component, GlobalTransform, Mat4, Reflect, ReflectComponent, Transform,
 };
@@ -22,89 +21,64 @@ pub struct PixelCameraBundle {
 }
 
 impl PixelCameraBundle {
-    /// Create a component bundle for a camera where the size of virtual pixels
-    /// are specified with `zoom`.
-    pub fn from_zoom(zoom: i32) -> Self {
-        let pixel_projection = PixelProjection {
-            zoom: zoom,
-            ..Default::default()
-        };
+    /// Create a component bundle for a camera with the specified projection.
+    pub fn new(pixel_projection: PixelProjection) -> Self {
         let far = pixel_projection.far;
-        let view_projection = pixel_projection.get_projection_matrix();
-        let frustum = Frustum::from_view_projection(&view_projection, &Vec3::ZERO, &Vec3::Z, far);
+        let transform = Transform::from_xyz(0.0, 0.0, far - 0.1);
+        let view_projection =
+            pixel_projection.get_projection_matrix() * transform.compute_matrix().inverse();
+        let frustum = Frustum::from_view_projection(
+            &view_projection,
+            &transform.translation,
+            &transform.back(),
+            pixel_projection.far(),
+        );
         Self {
             camera: Camera::default(),
             pixel_projection,
             visible_entities: Default::default(),
             frustum,
-            transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
+            transform,
             global_transform: Default::default(),
             marker: Camera2d,
         }
+    }
+
+    /// Create a component bundle for a camera where the size of virtual pixels
+    /// are specified with `zoom`.
+    pub fn from_zoom(zoom: i32) -> Self {
+        Self::new(PixelProjection {
+            zoom: zoom,
+            ..Default::default()
+        })
     }
 
     /// Create a component bundle for a camera where the size of virtual pixels
     /// is automatically set to fit the specified resolution inside the window.
     pub fn from_resolution(width: i32, height: i32) -> Self {
-        let pixel_projection = PixelProjection {
+        Self::new(PixelProjection {
             desired_width: Some(width),
             desired_height: Some(height),
             ..Default::default()
-        };
-        let far = pixel_projection.far;
-        let view_projection = pixel_projection.get_projection_matrix();
-        let frustum = Frustum::from_view_projection(&view_projection, &Vec3::ZERO, &Vec3::Z, far);
-        Self {
-            camera: Camera::default(),
-            pixel_projection,
-            visible_entities: Default::default(),
-            frustum,
-            transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
-            global_transform: Default::default(),
-            marker: Camera2d,
-        }
+        })
     }
 
     /// Create a component bundle for a camera where the size of virtual pixels
     /// is automatically set to fit the specified width inside the window.
     pub fn from_width(width: i32) -> Self {
-        let pixel_projection = PixelProjection {
+        Self::new(PixelProjection {
             desired_width: Some(width),
             ..Default::default()
-        };
-        let far = pixel_projection.far;
-        let view_projection = pixel_projection.get_projection_matrix();
-        let frustum = Frustum::from_view_projection(&view_projection, &Vec3::ZERO, &Vec3::Z, far);
-        Self {
-            camera: Camera::default(),
-            pixel_projection,
-            visible_entities: Default::default(),
-            frustum,
-            transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
-            global_transform: Default::default(),
-            marker: Camera2d,
-        }
+        })
     }
 
     /// Create a component bundle for a camera where the size of virtual pixels
     /// is automatically set to fit the specified height inside the window.
     pub fn from_height(height: i32) -> Self {
-        let pixel_projection = PixelProjection {
+        Self::new(PixelProjection {
             desired_height: Some(height),
             ..Default::default()
-        };
-        let far = pixel_projection.far;
-        let view_projection = pixel_projection.get_projection_matrix();
-        let frustum = Frustum::from_view_projection(&view_projection, &Vec3::ZERO, &Vec3::Z, far);
-        Self {
-            camera: Camera::default(),
-            pixel_projection,
-            visible_entities: Default::default(),
-            frustum,
-            transform: Transform::from_xyz(0.0, 0.0, far - 0.1),
-            global_transform: Default::default(),
-            marker: Camera2d,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
Specifically:

- add a frustum to the camera bundle,
- invert near and far in the projection.
