### PR TITLE
Migrate to bevy 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.7" }
+bevy = { version = "0.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_pixel_camera"
-version = "0.1.3"
+version = "0.2"
 authors = ["drakmaniso <moussault.laurent@gmail.com>"]
 edition = "2021"
 description = "A simple pixel-perfect camera plugin for Bevy, suitable for pixel-art"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ default), or it will not be pixel aligned.
 Also note that Bevy uses linear sampling by default for textures, which is
 not what you want for pixel art. The easiest way to change this is to insert the
 following resource on you app:
-
 ```rust
     App::new()
         .insert_resource(bevy::render::texture::ImageSettings::default_nearest())
@@ -39,12 +38,7 @@ crate simply upscale each sprite, and correctly align them on a virtual
 pixel grid. Another option would be to render the sprites to an offscrenn
 texture, and then upscale only this texture. There is advantages and
 drawbacks to both approaches:
-- the offscreen method is probably more efficient in most cases;
-- in both cases the coordinates of non-moving sprites must be manually kept
-  on integer coordinates;
-- forgetting to use rounded coordinates will result in much worse results
-  with the offscreen method; that's why this approach should probably be
-  paired with a specialized sprite system based on integer transforms;
+- the offscreen texture method is probably more efficient in most cases;
 - the method in this crate allows for smoother scrolling and movement of
   sprites, if you're willing to temporarily break the alignment on virtual
   pixels (this would be even more effective with a dedicated upscaling
@@ -89,7 +83,7 @@ fn setup(
 }
 ```
 
-## License
+### License
 
 Licensed under either of
 
@@ -97,3 +91,5 @@ Licensed under either of
 * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
+
+License: MIT OR Apache-2.0

--- a/README.md
+++ b/README.md
@@ -13,18 +13,26 @@ configure it in a specific way (you can't just use
 This plugin provides a camera which can be easily configured by specifying
 either the size of the virtual pixels, or the desired resolution.
 
-It also includes a quad mesh resource to replace the default one used in
-Bevy's `SpriteBundle`. The default quad has its origin at the center of the
-image, but if the image has an odd width or height, that origin is not
-pixel-aligned. The resource included in this plugin puts the origin at the
-bottom-left corner of the image.
+Note that if either the width or the height of your sprite is not divisible
+by 2, you need to change the anchor of the sprite (which is at the center by
+default), or it will not be pixel aligned.
 
-Finally, the crate also includes a separate plugin to put an opaque border
+Also note that Bevy uses linear sampling by default for textures, which is
+not what you want for pixel art. The easiest way to change this is to insert the
+following resource on you app:
+
+```rust
+    App::new()
+        .insert_resource(bevy::render::texture::ImageSettings::default_nearest())
+        ...
+```
+
+The crate also includes a separate plugin to put an opaque border
 around the desired resolution. This way, if the window size is not an exact
 multiple of the virtual resolution, anything out of bounds will still be
 hidden.
 
-### Comparison with other methods
+## Comparison with other methods
 
 There is several possible methods to render pixel-art based games. This
 crate simply upscale each sprite, and correctly align them on a virtual
@@ -42,7 +50,7 @@ drawbacks to both approaches:
   pixels (this would be even more effective with a dedicated upscaling
   shader).
 
-### Example code
+## Example code
 
 ```rust
 use bevy::prelude::*;
@@ -53,6 +61,7 @@ use bevy_pixel_camera::{
 
 fn main() {
     App::new()
+        .insert_resource(bevy::render::texture::ImageSettings::default_nearest())
         .add_plugins(DefaultPlugins)
         .add_plugin(PixelCameraPlugin)
         .add_plugin(PixelBorderPlugin {
@@ -68,6 +77,7 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     commands.spawn_bundle(PixelCameraBundle::from_resolution(320, 240));
+
     commands.spawn_bundle(SpriteBundle {
         texture: asset_server.load("my-pixel-art-sprite.png"),
         sprite: Sprite {
@@ -79,15 +89,7 @@ fn setup(
 }
 ```
 
-Run examples with:
-
-    $ cargo run --example flappin
-
-and:
-
-    $ cargo run --example mire
-
-### License
+## License
 
 Licensed under either of
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ around the desired resolution. This way, if the window size is not an exact
 multiple of the virtual resolution, anything out of bounds will still be
 hidden.
 
+A small example is included in the crate. Run it with:
+
+    $ cargo run --example flappin
+
 ## Comparison with other methods
 
 There is several possible methods to render pixel-art based games. This

--- a/examples/flappin.rs
+++ b/examples/flappin.rs
@@ -57,7 +57,7 @@ fn main() {
         })
         .insert_resource(Rng { mz: 0, mw: 0 })
         .insert_resource(ClearColor(Color::rgb(0.000001, 0.000001, 0.000001)))
-        .insert_resource(Timer::from_seconds(0.25, false))
+        .insert_resource(Timer::from_seconds(0.5, false))
         .insert_resource(Action {
             just_pressed: false,
         })
@@ -133,7 +133,11 @@ fn press_to_start(
     mut birds: Query<(&mut Transform, &mut BirdPhysics), With<Bird>>,
 ) {
     timer.tick(time.delta());
-    if timer.finished() && action.just_pressed {
+    if !timer.finished() {
+        action.just_pressed = false;
+        return;
+    }
+    if action.just_pressed {
         action.just_pressed = false;
         for (mut transform, mut physics) in birds.iter_mut() {
             *transform = Transform::from_xyz(BIRD_X, 0.0, 1.0);
@@ -391,7 +395,7 @@ fn animate_clouds(
     }
     let dt = time.delta().as_secs_f32();
     for (mut transform, mut sprite) in query.iter_mut() {
-        *transform = transform.mul_transform(Transform::from_xyz(-60.0 * dt, 0.0, 0.0));
+        *transform = transform.mul_transform(Transform::from_xyz(-30.0 * dt, 0.0, 0.0));
         if transform.translation.x + CLOUD_WIDTH < LEFT {
             let y = BOTTOM + 40.0 + rng.rand_range(0..(HEIGHT - 80.0 - CLOUD_HEIGHT) as u32) as f32;
             *transform = Transform::from_xyz(RIGHT, y, 0.0);

--- a/examples/flappin.rs
+++ b/examples/flappin.rs
@@ -1,6 +1,7 @@
+use bevy::prelude::*;
 use bevy::sprite::Anchor;
+use bevy::time::FixedTimestep;
 use bevy::window;
-use bevy::{core::FixedTimestep, prelude::*};
 use bevy_pixel_camera::{PixelBorderPlugin, PixelCameraBundle, PixelCameraPlugin};
 
 // GAME CONSTANTS /////////////////////////////////////////////////////////////
@@ -52,6 +53,7 @@ fn main() {
             present_mode: window::PresentMode::Mailbox,
             ..Default::default()
         })
+        .insert_resource(bevy::render::texture::ImageSettings::default_nearest())
         .add_plugins(DefaultPlugins)
         .add_plugin(PixelCameraPlugin)
         .add_plugin(PixelBorderPlugin {
@@ -63,7 +65,7 @@ fn main() {
         .add_startup_system(setup.label("setup"))
         .add_startup_system(spawn_bird.after("setup"))
         .add_startup_system(spawn_clouds.after("setup"))
-        .add_system(bevy::input::system::exit_on_esc_system)
+        .add_system(bevy::window::close_on_esc)
         .add_system(on_press)
         .add_system_set(
             SystemSet::on_update(GameState::StartScreen)

--- a/examples/mire.rs
+++ b/examples/mire.rs
@@ -5,6 +5,7 @@ use bevy_pixel_camera::{PixelCameraBundle, PixelCameraPlugin};
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.000001, 0.000001, 0.000001)))
+        .insert_resource(bevy::render::texture::ImageSettings::default_nearest())
         .add_plugins(DefaultPlugins)
         .add_plugin(PixelCameraPlugin)
         .add_startup_system(setup)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,10 @@
 //! multiple of the virtual resolution, anything out of bounds will still be
 //! hidden.
 //!
+//! A small example is included in the crate. Run it with:
+//!
+//!     $ cargo run --example flappin
+//!
 //! # Comparison with other methods
 //!
 //! There is several possible methods to render pixel-art based games. This

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,25 +29,20 @@
 //! multiple of the virtual resolution, anything out of bounds will still be
 //! hidden.
 //!
-//! ## Comparison with other methods
+//! # Comparison with other methods
 //!
 //! There is several possible methods to render pixel-art based games. This
 //! crate simply upscale each sprite, and correctly align them on a virtual
 //! pixel grid. Another option would be to render the sprites to an offscrenn
 //! texture, and then upscale only this texture. There is advantages and
 //! drawbacks to both approaches:
-//! - the offscreen method is probably more efficient in most cases;
-//! - in both cases the coordinates of non-moving sprites must be manually kept
-//!   on integer coordinates;
-//! - forgetting to use rounded coordinates will result in much worse results
-//!   with the offscreen method; that's why this approach should probably be
-//!   paired with a specialized sprite system based on integer transforms;
+//! - the offscreen texture method is probably more efficient in most cases;
 //! - the method in this crate allows for smoother scrolling and movement of
 //!   sprites, if you're willing to temporarily break the alignment on virtual
 //!   pixels (this would be even more effective with a dedicated upscaling
 //!   shader).
 //!
-//! ## Example code
+//! # Example code
 //!
 //! ```no_run
 //! use bevy::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,15 @@
 //! by 2, you need to change the anchor of the sprite (which is at the center by
 //! default), or it will not be pixel aligned.
 //!
+//! Also note that Bevy uses linear sampling by default for textures, which is
+//! not what you want for pixel art. The easiest way to change this is to insert the
+//! following resource on you app:
+//! ```no_run
+//!     App::new()
+//!         .insert_resource(bevy::render::texture::ImageSettings::default_nearest())
+//!         ...
+//! ```
+//!
 //! The crate also includes a separate plugin to put an opaque border
 //! around the desired resolution. This way, if the window size is not an exact
 //! multiple of the virtual resolution, anything out of bounds will still be
@@ -49,6 +58,7 @@
 //!
 //! fn main() {
 //!     App::new()
+//!         .insert_resource(bevy::render::texture::ImageSettings::default_nearest())
 //!         .add_plugins(DefaultPlugins)
 //!         .add_plugin(PixelCameraPlugin)
 //!         .add_plugin(PixelBorderPlugin {

--- a/src/pixel_camera.rs
+++ b/src/pixel_camera.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::{
-    Bundle, Component, GlobalTransform, Mat4, Reflect, ReflectComponent, Transform,
+    Bundle, Camera2d, Component, GlobalTransform, Mat4, Reflect, ReflectComponent, Transform,
 };
-use bevy::render::camera::{Camera, Camera2d, CameraProjection, DepthCalculation};
+use bevy::render::camera::{Camera, CameraProjection, CameraRenderGraph, DepthCalculation};
 use bevy::render::primitives::Frustum;
 use bevy::render::view::VisibleEntities;
 
@@ -12,12 +12,13 @@ use bevy::render::view::VisibleEntities;
 #[derive(Bundle)]
 pub struct PixelCameraBundle {
     pub camera: Camera,
+    pub camera_render_graph: CameraRenderGraph,
     pub pixel_projection: PixelProjection,
     pub visible_entities: VisibleEntities,
     pub frustum: Frustum,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
-    pub marker: Camera2d,
+    pub camera_2d: Camera2d,
 }
 
 impl PixelCameraBundle {
@@ -34,13 +35,14 @@ impl PixelCameraBundle {
             pixel_projection.far(),
         );
         Self {
-            camera: Camera::default(),
+            camera_render_graph: CameraRenderGraph::new(bevy::core_pipeline::core_2d::graph::NAME),
             pixel_projection,
             visible_entities: Default::default(),
             frustum,
             transform,
             global_transform: Default::default(),
-            marker: Camera2d,
+            camera: Camera::default(),
+            camera_2d: Camera2d::default(),
         }
     }
 

--- a/src/pixel_plugin.rs
+++ b/src/pixel_plugin.rs
@@ -5,7 +5,7 @@ use bevy::render::camera::{
 use bevy::render::primitives::Aabb;
 use bevy::render::view::{ComputedVisibility, Visibility, VisibleEntities};
 
-/// Provides the camera system, and the quad resource for sprite meshes.
+/// Provides the camera system.
 pub struct PixelCameraPlugin;
 
 impl Plugin for PixelCameraPlugin {


### PR DESCRIPTION
Adapt the code to the changes in Bevy 0.8. Mostly straightforward.

Note that the default for texture filtering has changed in 0.8, so it is now necessary to insert a resource for configuring it back to nearest filtering. Unfortunately, I don't think this can be done in the plugin (at least I couldn't get it to work), so this has to be done in each application.