### PR TITLE
Include only the necessary features in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,12 @@ license = "MIT OR Apache-2.0"
 bevy = { version = "0.8", default-features = false, features = ["render"] }
 
 [dev-dependencies]
-bevy = "0.8"
+bevy = { version = "0.8", default-features = false, features = ["bevy_winit", "bevy_asset", "png", "x11"] }
+
+[[example]]
+name = "flappin"
+required-features = ["bevy/bevy_winit", "bevy/bevy_asset", "bevy/png"]
+
+[[example]]
+name = "mire"
+required-features = ["bevy/bevy_winit", "bevy/bevy_asset", "bevy/png"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ categories = ["graphics", "game-development"]
 exclude = ["assets/**", ".vscode/**"]
 license = "MIT OR Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-bevy = { version = "0.8" }
+bevy = { version = "0.8", default-features = false, features = ["render"] }
+
+[dev-dependencies]
+bevy = "0.8"


### PR DESCRIPTION
I don't see the point in using all the features of `Bevy` when you only need rendering to work.
Take pity on the users (including me) who use `default-features = false` together with `Bevy`)))