### PR TITLE
Reduce bevy features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["assets/**", ".vscode/**"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.8", default-features = false, features = ["render"] }
+bevy = { version = "0.8", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_sprite"] }
 
 [dev-dependencies]
 bevy = { version = "0.8", default-features = false, features = ["bevy_winit", "bevy_asset", "png", "x11"] }


### PR DESCRIPTION
This PR makes the bevy features more specific, which reduces the amount of crates a build needs to pull in (from ~230 to ~200 dependencies, mostly skipping 3d rendering crates).