### PR TITLE
use PixelProjection's GlobalTransform in Borders

### DIFF
--- a/src/pixel_border.rs
+++ b/src/pixel_border.rs
@@ -64,20 +64,20 @@ fn resize_borders(
         (&PixelProjection, &GlobalTransform),
         Or<(Changed<PixelProjection>, Changed<GlobalTransform>)>,
     >,
-    mut borders: Query<(&mut Sprite, &mut GlobalTransform, &Border), Without<PixelProjection>>,
+    mut borders: Query<(&mut Sprite, &mut Transform, &Border), Without<PixelProjection>>,
 ) {
     if let Some((projection, transform)) = cameras.iter().next() {
         let z = projection.far - 0.2;
         let width = projection.desired_width.map(|w| w as f32).unwrap_or(0.0);
         let height = projection.desired_height.map(|h| h as f32).unwrap_or(0.0);
-        let left = transform.translation.x
+        let left = transform.translation().x
             + if projection.centered {
                 -(width / 2.0).round()
             } else {
                 0.0
             };
         let right = left + width;
-        let bottom = transform.translation.y
+        let bottom = transform.translation().y
             + if projection.centered {
                 (-height / 2.0).round()
             } else {
@@ -88,19 +88,19 @@ fn resize_borders(
         for (mut sprite, mut transform, border) in borders.iter_mut() {
             match border {
                 Border::Left => {
-                    *transform = GlobalTransform::from_xyz(left - width, bottom - height, z);
+                    *transform = Transform::from_xyz(left - width, bottom - height, z);
                     sprite.custom_size = Some(Vec2::new(width, 3.0 * height));
                 }
                 Border::Right => {
-                    *transform = GlobalTransform::from_xyz(right, bottom - height, z);
+                    *transform = Transform::from_xyz(right, bottom - height, z);
                     sprite.custom_size = Some(Vec2::new(width, 3.0 * height));
                 }
                 Border::Top => {
-                    *transform = GlobalTransform::from_xyz(left - width, top, z);
+                    *transform = Transform::from_xyz(left - width, top, z);
                     sprite.custom_size = Some(Vec2::new(3.0 * width, height));
                 }
                 Border::Bottom => {
-                    *transform = GlobalTransform::from_xyz(left - width, bottom - height, z);
+                    *transform = Transform::from_xyz(left - width, bottom - height, z);
                     sprite.custom_size = Some(Vec2::new(3.0 * width, height));
                 }
             }

--- a/src/pixel_border.rs
+++ b/src/pixel_border.rs
@@ -88,19 +88,19 @@ fn resize_borders(
         for (mut sprite, mut transform, border) in borders.iter_mut() {
             match border {
                 Border::Left => {
-                    *transform = Transform::from_xyz(left - width, bottom - height, z);
+                    *transform = GlobalTransform::from_xyz(left - width, bottom - height, z);
                     sprite.custom_size = Some(Vec2::new(width, 3.0 * height));
                 }
                 Border::Right => {
-                    *transform = Transform::from_xyz(right, bottom - height, z);
+                    *transform = GlobalTransform::from_xyz(right, bottom - height, z);
                     sprite.custom_size = Some(Vec2::new(width, 3.0 * height));
                 }
                 Border::Top => {
-                    *transform = Transform::from_xyz(left - width, top, z);
+                    *transform = GlobalTransform::from_xyz(left - width, top, z);
                     sprite.custom_size = Some(Vec2::new(3.0 * width, height));
                 }
                 Border::Bottom => {
-                    *transform = Transform::from_xyz(left - width, bottom - height, z);
+                    *transform = GlobalTransform::from_xyz(left - width, bottom - height, z);
                     sprite.custom_size = Some(Vec2::new(3.0 * width, height));
                 }
             }

--- a/src/pixel_border.rs
+++ b/src/pixel_border.rs
@@ -61,10 +61,10 @@ pub fn spawn_borders(mut commands: Commands, color: Res<BorderColor>) {
 
 fn resize_borders(
     cameras: Query<
-        (&PixelProjection, &Transform),
-        Or<(Changed<PixelProjection>, Changed<Transform>)>,
+        (&PixelProjection, &GlobalTransform),
+        Or<(Changed<PixelProjection>, Changed<GlobalTransform>)>,
     >,
-    mut borders: Query<(&mut Sprite, &mut Transform, &Border), Without<PixelProjection>>,
+    mut borders: Query<(&mut Sprite, &mut GlobalTransform, &Border), Without<PixelProjection>>,
 ) {
     if let Some((projection, transform)) = cameras.iter().next() {
         let z = projection.far - 0.2;


### PR DESCRIPTION
Hello cool lib :)

in my game i am planning to use multiple of these cameras, and they are added as Children to a parent node.
I only adjust the parent transform, such that children are moved implicity.

The PixelBorderPlugin doesn't adjust to changes in a pixelprojection's GlobalTransform, however.

This shouldn't break anything for current users.