### PR TITLE
Fix fullscreen bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_pixel_camera"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["drakmaniso <moussault.laurent@gmail.com>"]
 edition = "2021"
 description = "A simple pixel-perfect camera plugin for Bevy, suitable for pixel-art"

--- a/src/pixel_plugin.rs
+++ b/src/pixel_plugin.rs
@@ -37,7 +37,7 @@ impl Plugin for PixelCameraPlugin {
             )
             .add_systems(
                 PostUpdate,
-                super::pixel_zoom_system.before(camera::camera_system::<OrthographicProjection>),
+                super::pixel_zoom_system.after(camera::camera_system::<OrthographicProjection>),
             );
     }
 }

--- a/src/pixel_zoom.rs
+++ b/src/pixel_zoom.rs
@@ -46,6 +46,9 @@ pub(crate) fn pixel_zoom_system(
 ) {
     // Most of the change detection code is copied from `bevy_render/src/camera`
 
+    // TODO: maybe this can be replaced with just monitoring
+    // `OrthographicProjection` for changes?
+
     let primary_window = primary_window.iter().next();
 
     let mut changed_window_ids = HashSet::new();


### PR DESCRIPTION
When the window size suddenly changed (i.e. when going full-screen or maximizing), the correct pixel ratio was not set until another change occurred.