### PR TITLE
Upgrade to work with Bevy 0.15 from Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "bevy_pixel_camera"
-version = "0.13.0"
+version = "0.15.0"
 authors = ["drakmaniso <moussault.laurent@gmail.com>"]
-edition = "2021"
+edition = "2024"
 description = "A simple pixel-perfect camera plugin for Bevy, suitable for pixel-art"
 readme = "README.md"
 repository = "https://github.com/drakmaniso/bevy_pixel_camera"
@@ -12,25 +12,28 @@ exclude = ["assets/**", ".vscode/**"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.13", default-features = false, features = [
+bevy = { version = "0.15.0", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_sprite",
+    "bevy_window",
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.13", default-features = false, features = [
+bevy = { version = "0.15.0", default-features = false, features = [
     "bevy_winit",
     "bevy_asset",
+    "bevy_state",
     "png",
-    "multi-threaded",
+    "multi_threaded",
     "x11",
 ] }
 
 [[example]]
 name = "flappin"
-required-features = ["bevy/bevy_winit", "bevy/bevy_asset", "bevy/png"]
 
 [[example]]
 name = "mire"
-required-features = ["bevy/bevy_winit", "bevy/bevy_asset", "bevy/png"]
+
+[[example]]
+name = "readme"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ bevy = { version = "0.15.0", default-features = false, features = [
     "png",
     "multi_threaded",
     "x11",
+    "wayland"
 ] }
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ fn setup(
     asset_server: Res<AssetServer>,
 ) {
     commands.spawn((
-        Camera2dBundle::default(),
+        Camera2d,
         PixelZoom::FitSize {
             width: 320,
             height: 180,
@@ -73,14 +73,12 @@ fn setup(
         PixelViewport,
     ));
 
-    commands.spawn(SpriteBundle {
-        texture: asset_server.load("my-pixel-art-sprite.png"),
-        sprite: Sprite {
+    commands.spawn(
+        Sprite {
+            image: asset_server.load("mire-64x64.png"),
             anchor: Anchor::BottomLeft,
             ..Default::default()
-        },
-        ..Default::default()
-    });
+        });
 }
 ```
 
@@ -94,6 +92,7 @@ cargo run --example flappin
 
 | bevy | bevy_pixel_camera |
 |------|-------------------|
+| 0.15 | 0.15              |
 | 0.13 | 0.13              |
 | 0.12 | 0.12              |
 | 0.11 | 0.5.2             |
@@ -112,6 +111,30 @@ creating the camera bundle (see example above).
 The `PixelCameraBundle` has been deprecated. Replace it with a standard
 `Camera2dBundle`, to which you add the `PixelZoom` and `PixelViewport`
 components.
+
+### Migration guide: 0.12 to 0.15 (Bevy 0.12 to 0.15)
+
+There were a lot of API changes from 0.12 to 0.15 including numerous
+trait method name changes and some functional changes as well.
+
+* Removed `required-features` from examples in Cargo.toml
+* Replaced deprecated `push_children` with `add_children`
+* Changes to work with method changes in `CameraProjection`
+* Changed to work with API renames in `VisibilitySystems`
+* `ScalingMode::WindowSize` changes, zoom no longer held in Enum
+* Flappin Example
+  * Inserted gamestate as a resource
+  * `close_on_esc` deprecated, added own implementation
+  * Arguments to `TextureAtlasLayout::from_grid` updated
+  * Replaced deprecated `Camera2dBundle`  with `Camera2d` component
+  * Removed gamepad code
+    * 0.15 crashes if no gamepad is plugged in
+  * Removed queries for `TextureAtlas` components
+    * `TextureAtlas` are now optional members of `Sprite`
+* Mire Example
+  * Updated for 0.15
+* Added readme example
+    * Duplicate of example code in this file
 
 ## License
 

--- a/examples/mire.rs
+++ b/examples/mire.rs
@@ -1,81 +1,75 @@
+use bevy::math::{uvec2, vec3};
 use bevy::prelude::*;
 use bevy_pixel_camera::{PixelCameraPlugin, PixelViewport, PixelZoom};
 
-const WIDTH: i32 = 320;
-const HEIGHT: i32 = 180;
+// Pixel screen dimensions
+const SCREEN_DIMS: UVec2 = uvec2(320, 180);
 
+
+// Main
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(0.2, 0.2, 0.2)))
+        .insert_resource(ClearColor(Color::srgb(0.2, 0.2, 0.2)))
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_plugins(PixelCameraPlugin)
         .add_systems(Startup, setup)
-        .add_systems(Update, bevy::window::close_on_esc)
+        .add_systems(Update, close_on_esc)
         .run();
 }
 
+// Setup everything
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let mire_handle = asset_server.load("mire-64x64.png");
+
     // Add a camera that will always fit the virtual resolution WIDTH x HEIGHT
     // inside the window.
     commands.spawn((
-        Camera2dBundle::default(),
+        Camera2d,
         PixelZoom::FitSize {
-            width: WIDTH,
-            height: HEIGHT,
+            width: SCREEN_DIMS.x as i32,
+            height: SCREEN_DIMS.y as i32,
         },
         PixelViewport,
     ));
 
-    let mire_handle = asset_server.load("mire-64x64.png");
+    // Create Vec3 of the screen dimensions
+    let v3_dims = SCREEN_DIMS.as_vec2().extend(0.0);
 
-    // Add a mire sprite in the center of the window.
-    commands.spawn(SpriteBundle {
-        texture: mire_handle.clone(),
-        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
-        ..Default::default()
-    });
+    // 5 sprite positions
+    // 1 in the center and 4 around the edges
+    let positions = [
+        (0.0, 0.0),
+        (-0.5, -0.5),
+        (0.5, -0.5),
+        (-0.5, 0.5),
+        (0.5, 0.5),
+    ]
+    .map(|(x, y)| vec3(x, y, 0.0) * v3_dims);
 
-    // Add a mire sprite in the bottom-left corner of our virtual resolution.
-    commands.spawn(SpriteBundle {
-        texture: mire_handle.clone(),
-        transform: Transform::from_translation(Vec3::new(
-            -(WIDTH / 2) as f32,
-            -(HEIGHT / 2) as f32,
-            0.0,
-        )),
-        ..Default::default()
-    });
+    // Create a sprite entity for each position
+    for pos in positions {
+        commands.spawn((
+            Sprite {
+                image: mire_handle.clone(),
+                ..Default::default()
+            },
+            Transform::from_translation(pos),
+        ));
+    }
+}
 
-    // Add a mire sprite in the bottom-right corner of our virtual resolution.
-    commands.spawn(SpriteBundle {
-        texture: mire_handle.clone(),
-        transform: Transform::from_translation(Vec3::new(
-            (WIDTH / 2) as f32,
-            -(HEIGHT / 2) as f32,
-            0.0,
-        )),
-        ..Default::default()
-    });
-
-    // Add a mire sprite in the top-left corner of our virtual resolution.
-    commands.spawn(SpriteBundle {
-        texture: mire_handle.clone(),
-        transform: Transform::from_translation(Vec3::new(
-            -(WIDTH / 2) as f32,
-            (HEIGHT / 2) as f32,
-            0.0,
-        )),
-        ..Default::default()
-    });
-
-    // Add a mire sprite in the top-right corner of our virtual resolution.
-    commands.spawn(SpriteBundle {
-        texture: mire_handle.clone(),
-        transform: Transform::from_translation(Vec3::new(
-            (WIDTH / 2) as f32,
-            (HEIGHT / 2) as f32,
-            0.0,
-        )),
-        ..Default::default()
-    });
+// Simple system to close on ESC
+// after close_on_esc was deprecated
+fn close_on_esc(
+    mut commands: Commands,
+    focused_windows: Query<(Entity, &Window)>,
+    input: Res<ButtonInput<KeyCode>>,
+) {
+    for (window, focus) in focused_windows.iter() {
+        if focus.focused {
+            if input.just_pressed(KeyCode::Escape) {
+                commands.entity(window).despawn();
+            }
+        }
+    }
 }

--- a/examples/mire.rs
+++ b/examples/mire.rs
@@ -11,6 +11,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::srgb(0.2, 0.2, 0.2)))
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
+        .insert_resource::<Msaa>(Msaa::Off)
         .add_plugins(PixelCameraPlugin)
         .add_systems(Startup, setup)
         .add_systems(Update, close_on_esc)

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,0 +1,34 @@
+use bevy::prelude::*;
+use bevy::sprite::Anchor;
+use bevy_pixel_camera::{
+    PixelCameraPlugin, PixelZoom, PixelViewport
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
+        .add_plugins(PixelCameraPlugin)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+) {
+    commands.spawn((
+        Camera2d,
+        PixelZoom::FitSize {
+            width: 320,
+            height: 180,
+        },
+        PixelViewport,
+    ));
+
+    commands.spawn(
+        Sprite {
+            image: asset_server.load("mire-64x64.png"),
+            anchor: Anchor::BottomLeft,
+            ..Default::default()
+        });
+}

--- a/src/pixel_border.rs
+++ b/src/pixel_border.rs
@@ -64,7 +64,7 @@ pub fn spawn_borders(mut commands: Commands, color: Res<BorderColor>) {
 
     commands
         .spawn((SpatialBundle::default(), Name::new("Borders")))
-        .push_children(&[left, right, top, bottom]);
+        .add_children(&[left, right, top, bottom]);
 }
 
 #[allow(clippy::type_complexity)]

--- a/src/pixel_camera.rs
+++ b/src/pixel_camera.rs
@@ -6,7 +6,7 @@ use bevy::prelude::{
     Bundle, Camera2d, Component, EventReader, GlobalTransform, Mat4, Query, Reflect,
     ReflectComponent, Transform, UVec2, With,
 };
-use bevy::render::camera::{Camera, CameraProjection, CameraRenderGraph, Viewport};
+use bevy::render::camera::{Camera, CameraProjection, CameraRenderGraph, Viewport, SubCameraView};
 use bevy::render::primitives::Frustum;
 use bevy::render::view::VisibleEntities;
 use bevy::window::{Window, WindowResized};
@@ -32,8 +32,8 @@ impl PixelCameraBundle {
     pub fn new(pixel_projection: PixelProjection) -> Self {
         let transform = Transform::from_xyz(0.0, 0.0, 0.0);
         let view_projection =
-            pixel_projection.get_projection_matrix() * transform.compute_matrix().inverse();
-        let frustum = Frustum::from_view_projection_custom_far(
+            pixel_projection.get_clip_from_view() * transform.compute_matrix().inverse();
+        let frustum = Frustum::from_clip_from_world_custom_far(
             &view_projection,
             &transform.translation,
             &transform.back(),
@@ -144,7 +144,9 @@ pub struct PixelProjection {
 }
 
 impl CameraProjection for PixelProjection {
-    fn get_projection_matrix(&self) -> Mat4 {
+
+
+    fn get_clip_from_view(&self) -> Mat4 {
         Mat4::orthographic_rh(
             self.left,
             self.right,
@@ -191,6 +193,12 @@ impl CameraProjection for PixelProjection {
             Vec3A::new(self.left, self.top, z_far),      // top left
             Vec3A::new(self.left, self.bottom, z_far),   // bottom left
         ]
+    }
+
+
+    fn get_clip_from_view_for_sub(&self, _sub_view: &SubCameraView) -> Mat4 {
+        println!("This shouldn't be called I think!");
+        self.get_clip_from_view()
     }
 }
 

--- a/src/pixel_plugin.rs
+++ b/src/pixel_plugin.rs
@@ -28,7 +28,7 @@ impl Plugin for PixelCameraPlugin {
             .add_systems(
                 PostUpdate,
                 visibility::update_frusta::<PixelProjection>
-                    .in_set(visibility::VisibilitySystems::UpdateOrthographicFrusta)
+                    .in_set(visibility::VisibilitySystems::UpdateFrusta)
                     .after(camera::camera_system::<PixelProjection>)
                     .after(TransformSystem::TransformPropagate)
                     .ambiguous_with(visibility::update_frusta::<PerspectiveProjection>)

--- a/src/pixel_zoom.rs
+++ b/src/pixel_zoom.rs
@@ -86,12 +86,11 @@ pub(crate) fn pixel_zoom_system(
 
                 let zoom = auto_zoom(pixel_zoom, logical_size) as f32;
                 match projection.scaling_mode {
-                    ScalingMode::WindowSize(previous_zoom) => {
-                        if previous_zoom != zoom {
-                            projection.scaling_mode = ScalingMode::WindowSize(zoom)
-                        }
+                    ScalingMode::WindowSize => {
+                        projection.scale = 1.0 / zoom;
                     }
-                    _ => projection.scaling_mode = ScalingMode::WindowSize(zoom),
+
+                    _ => projection.scaling_mode = ScalingMode::WindowSize,
                 }
 
                 if pixel_viewport.is_some() {


### PR DESCRIPTION
### Migration guide: 0.12 to 0.15 (Bevy 0.12 to 0.15)

There were a lot of API changes from 0.12 to 0.15 including numerous
trait method name changes and some functional changes as well.

* Removed `required-features` from examples in Cargo.toml
* Replaced deprecated `push_children` with `add_children`
* Changes to work with method changes in `CameraProjection`
* Changed to work with API renames in `VisibilitySystems`
* `ScalingMode::WindowSize` changes, zoom no longer held in Enum
* Flappin Example
  * Inserted gamestate as a resource
  * `close_on_esc` deprecated, added own implementation
  * Arguments to `TextureAtlasLayout::from_grid` updated
  * Replaced deprecated `Camera2dBundle`  with `Camera2d` component
  * Removed gamepad code
    * 0.15 crashes if no gamepad is plugged in
  * Removed queries for `TextureAtlas` components
    * `TextureAtlas` are now optional members of `Sprite`
* Mire Example
  * Updated for 0.15
* Added readme example
    * Duplicate of example code in this file

